### PR TITLE
make the propane always print

### DIFF
--- a/.ipynb_checkpoints/TxyNotebook-checkpoint.ipynb
+++ b/.ipynb_checkpoints/TxyNotebook-checkpoint.ipynb
@@ -66,23 +66,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[4.53678, 1149.36, 24.906, 277.6, 360.8]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[4.53678, 1149.36, 24.906, 277.6, 360.8]\n"
+     ]
     }
    ],
    "source": [
     "propane = get_antoine_coefficient('propane',350)\n",
-    "propane"
+    "print(propane)"
    ]
   },
   {

--- a/TxyNotebook.ipynb
+++ b/TxyNotebook.ipynb
@@ -66,23 +66,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[4.53678, 1149.36, 24.906, 277.6, 360.8]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[4.53678, 1149.36, 24.906, 277.6, 360.8]\n"
+     ]
     }
    ],
    "source": [
     "propane = get_antoine_coefficient('propane',350)\n",
-    "propane"
+    "print(propane)"
    ]
   },
   {


### PR DESCRIPTION
uses the print command to ensure that propane array will always display